### PR TITLE
Subclassing of releases and groups WIP

### DIFF
--- a/lib/CPAN/Changes.pm
+++ b/lib/CPAN/Changes.pm
@@ -39,6 +39,7 @@ sub new {
         preamble => '',
         releases => {},
         months   => \%months,
+        release_class => 'CPAN::Changes::Release',
         @_,
     }, $class;
 }
@@ -148,7 +149,7 @@ sub load_string {
             undef $n unless length $n;
 
             push @releases,
-                CPAN::Changes::Release->new(
+                $changes->build_release(
                 version      => $v,
                 date         => $d,
                 _parsed_date => $match,
@@ -259,7 +260,7 @@ sub add_release {
 
     for my $release ( @_ ) {
         my $new = Scalar::Util::blessed $release ? $release
-            : CPAN::Changes::Release->new( %$release );
+            : $self->build_release( %$release );
         $self->{ releases }->{ $new->version } = $new;
     }
 }
@@ -301,6 +302,12 @@ sub serialize {
     $output =~ s/\n\n+\z/\n/;
 
     return $output;
+}
+
+sub build_release {
+    my $self = shift;
+
+    return $self->{ release_class }->new( @_ );
 }
 
 1;
@@ -419,6 +426,10 @@ groups are sorted alphabetically.
 =head2 delete_empty_groups( )
 
 Deletes change groups without changes in all releases.
+
+=head2 build_release( )
+
+TODO
 
 =head1 DEALING WITH "NEXT VERSION" PLACEHOLDERS
 

--- a/lib/CPAN/Changes/Release.pm
+++ b/lib/CPAN/Changes/Release.pm
@@ -11,6 +11,7 @@ sub new {
     my $class = shift;
     return bless {
         changes => {},
+        group_class => 'CPAN::Changes::Group',
         @_,
     }, $class;
 }
@@ -101,10 +102,10 @@ sub get_group {
         $group = shift;
     }
     if ( !exists $self->{ changes }->{ $group } ) {
-        $self->{ changes }->{ $group } = CPAN::Changes::Group->new( name => $group );
+        $self->{ changes }->{ $group } = $self->build_group( name => $group );
     }
     if ( not blessed $self->{changes}->{$group} ) {
-       $self->{ changes }->{ $group } = CPAN::Changes::Group->new( name => $group , changes => $self->{changes}->{$group} );
+       $self->{ changes }->{ $group } = $self->build_group( name => $group , changes => $self->{changes}->{$group} );
     }
 
     return $self->{ changes }->{ $group };
@@ -129,7 +130,7 @@ sub group_values {
 
 sub add_group {
     my $self = shift;
-    $self->{ changes }->{ $_ } = CPAN::Changes::Group->new( name =>  $_ ) for @_;
+    $self->{ changes }->{ $_ } = $self->build_group( name =>  $_ ) for @_;
 }
 
 sub delete_group {
@@ -160,6 +161,12 @@ sub serialize {
     $output .= "\n";
 
     return $output;
+}
+
+sub build_group {
+    my $self = shift;
+
+    return $self->{ group_class }->new( @_ );
 }
 
 1;
@@ -279,6 +286,10 @@ as it is instead determined from C<< $group_object->name >>
 =head2 group_values( sort => \&sorting_function )
 
 Works like L</groups> but instead returns C<CPAN::Changes::Group> compatible objects.
+
+=head1 build_group( )
+
+TODO
 
 
 


### PR DESCRIPTION

The intention is to make easy to load / parse a Changes file and end up with custom classes for releases and groups with the minimum amount of code. For illustration

```
$changes = CPAN::Changes->load(
    './Changes',
    release_class => 'CustomRelease',
);
```